### PR TITLE
BAU: Adds require on production release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,8 @@ workflows:
           name: create-production-release
           context: trade-tariff-releases
           image-name: tariff-tea-production
+          requires:
+            - apply-terraform-staging
           <<: *filter-main
 
       - write-docker-tag:


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes production releases which depend on live images being built

### Why?

I am doing this because:

- This is a stop gap since we would normally have some kind of verifying test after a release to staging that would determine whether we are safe to deploy to production

### AC

- Tested
- Shared with stakeholders
- Pair reviewed
