### PR TITLE
HMRC-1446: Migrate backend locking to use_lockfile 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 env:
-  TERRAFORM_VERSION: 1.11.0
+  TERRAFORM_VERSION: 1.12.2
   PYTHON_VERSION: 3
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 yarn 1.22.10
 nodejs 20.9.0
-terraform 1.11.0
+terraform 1.12.2

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers

--- a/terraform/backends/production.tfbackend
+++ b/terraform/backends/production.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-production-382373577178"
 key            = "tariff-commodi-tea.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "tea-lock-382373577178"
+use_lockfile   = true

--- a/terraform/backends/staging.tfbackend
+++ b/terraform/backends/staging.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-staging-451934005581"
 key            = "tariff-commodi-tea.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "tea-lock-451934005581"
+use_lockfile   = true

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11.0"
+  required_version = ">= 1.12"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Jira link

[HMRC-1446](https://transformuk.atlassian.net/browse/HMRC-1446)

### What?

I have added/removed/altered:

- [ ] Removed dynamodb_table from backend config in staging and prod
- [ ]  Added use_lockfile = true to enable locking with native support in staging and prod
- [ ] Upgraded terraform version

### Why?

I am doing this because:

- Terraform has deprecated dynamodb_table in favour of use_lockfile

#### References

[Terraform S3 backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3)
